### PR TITLE
[TNS 732] Join Players in a match - Implementation

### DIFF
--- a/Uno-App/Source/Private/GameLifecycleController.cpp
+++ b/Uno-App/Source/Private/GameLifecycleController.cpp
@@ -22,7 +22,6 @@ void GameLifecycleController::Tick()
 
     Core::LogMessage("Press any key to quit the game");
     std::cin.get();
-    std::cin.get();
 
     Core::CloseApp();
 }

--- a/Uno-App/Source/Private/Match.cpp
+++ b/Uno-App/Source/Private/Match.cpp
@@ -30,6 +30,15 @@ void Match::JoinPlayers(const int& number)
 EntityPtr<Player> Match::CreatePlayer(const int& index)
 {
     const auto playerName = Core::GetInput<std::string>("Player " + std::to_string(index) + ": What's your name? ");
+    for (EntityPtr<Player> current : JoinedPlayers)
+    {
+        if(current->GetName() == playerName)
+        {
+            Core::LogMessage("You can't assign your name as " + playerName + " because another player already has this name");
+            return CreatePlayer(index);
+        }
+    }
+
     return EntityPtr<Player>::MakeEntityPtr(playerName);
 }
 

--- a/Uno-App/Source/Private/Match.cpp
+++ b/Uno-App/Source/Private/Match.cpp
@@ -39,7 +39,7 @@ EntityPtr<Player> Match::CreatePlayer(const int& index)
         }
     }
 
-    return EntityPtr<Player>::MakeEntityPtr(playerName);
+    return EntityPtr<Player>::MakeEntityPtr(playerName, index);
 }
 
 void Match::CreateDeck()

--- a/Uno-App/Source/Private/Player.cpp
+++ b/Uno-App/Source/Private/Player.cpp
@@ -1,5 +1,10 @@
 ﻿#include "Public/Player.h"
 
-Player::Player(const std::string& name)
-    :Entity(name)
+Player::Player(const std::string& name, const int& index)
+    :Entity(name), Index{index}
 {}
+
+const std::string Player::GetDisplayName()
+{
+    return "Player " + std::to_string(Index)  + ": " + GetName();
+}

--- a/Uno-App/Source/Public/Player.h
+++ b/Uno-App/Source/Public/Player.h
@@ -3,6 +3,10 @@
 
 class Player : public Entity
 {
+private:
+    int Index;
+    
 public:
-    Player(const std::string& name);
+    Player(const std::string& name, const int& index);
+    const std::string GetDisplayName();
 };

--- a/Uno-Core/Source/Core/Core.h
+++ b/Uno-Core/Source/Core/Core.h
@@ -16,6 +16,8 @@ public:
         std::cout << message;
         std::cin >> returnValue;
         std::cout << std::endl;
+        std::cin.clear();
+        std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 
         return returnValue;
     }


### PR DESCRIPTION
Players can join a match respecting some requisites:
- It's only possible to join at least 2 players, up to 10
- Every player will store its own index
- Each player must enter your name
- It's not possible to have two players with the same name
- A list of players joined is created
- It's possible to show a display name for each player that respect the following rule: "Player {index} - Name" (e.g.: "Player 1: John")
- Also improved the Get Input method to ignore any other data after space