### PR TITLE
[TNS 738 & 739] Buy +2 card and Reverse card actions implemented

### DIFF
--- a/Uno-App/Source/Private/Card.cpp
+++ b/Uno-App/Source/Private/Card.cpp
@@ -48,7 +48,7 @@ std::string Card::GetConsoleColorCode(EColor color)
     return DEFAULT_COLOR;
 }
 
-bool Card::CanBeTossed(EntityPtr<Card> other)
+bool Card::CanTossCardOnMe(EntityPtr<Card> other)
 {
     return !other.IsValid() || Color == other->GetColor();
 }

--- a/Uno-App/Source/Private/JumpCard.cpp
+++ b/Uno-App/Source/Private/JumpCard.cpp
@@ -16,7 +16,7 @@ EntityPtr<Round> JumpCard::GetCustomRound(const int roundIndex)
     return static_cast<EntityPtr<Round>>(EntityPtr<JumpRound>::MakeEntityPtr(roundIndex));
 }
 
-bool JumpCard::CanBeTossed(EntityPtr<Card> other)
+bool JumpCard::CanTossCardOnMe(EntityPtr<Card> other)
 {
     if(other.IsValid())
     {
@@ -27,5 +27,5 @@ bool JumpCard::CanBeTossed(EntityPtr<Card> other)
         }
     }
 
-    return Card::CanBeTossed(other);
+    return Card::CanTossCardOnMe(other);
 }

--- a/Uno-App/Source/Private/JumpRound.cpp
+++ b/Uno-App/Source/Private/JumpRound.cpp
@@ -1,6 +1,5 @@
-#include "JumpRound.h"
-
-#include "Player.h"
+#include "Public/JumpRound.h"
+#include "Public/Player.h"
 #include "Core/Core.h"
 
 JumpRound::JumpRound(int index)

--- a/Uno-App/Source/Private/Match.cpp
+++ b/Uno-App/Source/Private/Match.cpp
@@ -93,10 +93,6 @@ void Match::SortCardsToPlayers()
         {
             player->BuyDeckCard(Deck.get());
         }
-
-        auto card = static_cast<EntityPtr<Card>>(EntityPtr<MustBuyCard>::MakeEntityPtr( EColor::Blue, 2));
-        Deck->AddCardToDeck(card);
-        player->BuyDeckCard(Deck.get());
     }
 }
 

--- a/Uno-App/Source/Private/Match.cpp
+++ b/Uno-App/Source/Private/Match.cpp
@@ -5,9 +5,9 @@
 #include "Public/Player.h"
 #include "Public/ICustomRoundCard.h"
 #include "Public/Round.h"
-#include <stdlib.h>
 
 #include "Public/IPostRoundAction.h"
+#include "Public/MustBuyCard.h"
 
 Match::Match(const std::string& matchName)
     : Entity{matchName}, CurrentTurn{0}, Flow{ETurnFlow::Clockwise}
@@ -93,6 +93,10 @@ void Match::SortCardsToPlayers()
         {
             player->BuyDeckCard(Deck.get());
         }
+
+        auto card = static_cast<EntityPtr<Card>>(EntityPtr<MustBuyCard>::MakeEntityPtr( EColor::Blue, 2));
+        Deck->AddCardToDeck(card);
+        player->BuyDeckCard(Deck.get());
     }
 }
 
@@ -101,7 +105,6 @@ void Match::SetupTurnFlow()
     CurrentPlayerIndex = Core::RandomRange(0, PlayersCount - 1);
     Flow = Core::RandomRange(0, 1) == 0 ? ETurnFlow::Clockwise : ETurnFlow::AntiClockwise;
 }
-
 
 void Match::PostRoundAction(const EntityPtr<Card>& tossedCard)
 {
@@ -157,9 +160,10 @@ EntityPtr<Round> Match::MakeRound()
 void Match::PlayTurn()
 {
     const auto currentPlayerTurn = JoinedPlayers[CurrentPlayerIndex];
-    LastCard = Deck->GetLastTossedCard();
 
     EntityPtr<Round> newRound = MakeRound();
+    LastCard = Deck->GetLastTossedCard();
+
     newRound->RunRound(currentPlayerTurn, Deck, Flow);
 
     if(currentPlayerTurn->GetCards().empty())

--- a/Uno-App/Source/Private/MustBuyCard.cpp
+++ b/Uno-App/Source/Private/MustBuyCard.cpp
@@ -1,5 +1,7 @@
 #include "Public/MustBuyCard.h"
 
+#include "Public/MustBuyRound.h"
+
 MustBuyCard::MustBuyCard(const EColor& color, int amountToBuy)
     : Card{"Buy +" + std::to_string(amountToBuy), color}, AmountToBuy{amountToBuy}
 {}
@@ -14,17 +16,33 @@ std::string MustBuyCard::GetCardTypeName() const
     return "+" + std::to_string(AmountToBuy);
 }
 
-bool MustBuyCard::CanBeTossed(EntityPtr<Card> other)
+bool MustBuyCard::CanTossCardOnMe(EntityPtr<Card> other)
 {
     if(other.IsValid())
     {
         const auto mustBuyCard = static_cast<EntityPtr<MustBuyCard>>(other);
-        if(mustBuyCard.IsValid() &&
-            mustBuyCard->GetAmountToBuy() == AmountToBuy)
+        if(mustBuyCard.IsValid()
+            && mustBuyCard->GetAmountToBuy() == AmountToBuy)
         {
             return true;
         }
     }
 
-    return Card::CanBeTossed(other);
+    return !IsInRound && Card::CanTossCardOnMe(other);
+}
+
+EntityPtr<Round> MustBuyCard::GetCustomRound(int roundIndex)
+{
+    IsInRound = true;
+    return static_cast<EntityPtr<Round>>(EntityPtr<MustBuyRound>::MakeEntityPtr(roundIndex, AmountToBuy + Cumulated));
+}
+
+void MustBuyCard::ClearRound()
+{
+    IsInRound = false;
+}
+
+void MustBuyCard::Cumulate(int amount)
+{
+    Cumulated = amount;
 }

--- a/Uno-App/Source/Private/NumberCard.cpp
+++ b/Uno-App/Source/Private/NumberCard.cpp
@@ -9,7 +9,7 @@ std::string NumberCard::GetCardTypeName() const
     return std::to_string(Number);
 }
 
-bool NumberCard::CanBeTossed(EntityPtr<Card> other)
+bool NumberCard::CanTossCardOnMe(EntityPtr<Card> other)
 {
     if(other.IsValid())
     {
@@ -21,5 +21,5 @@ bool NumberCard::CanBeTossed(EntityPtr<Card> other)
         }
     }
 
-    return Card::CanBeTossed(other);
+    return Card::CanTossCardOnMe(other);
 }

--- a/Uno-App/Source/Private/Player.cpp
+++ b/Uno-App/Source/Private/Player.cpp
@@ -33,7 +33,7 @@ bool Player::CanTossCard(const EntityPtr<Card>& lastTossedCard)
             continue;
         }
 
-        if(card->CanBeTossed(lastTossedCard))
+        if(lastTossedCard->CanTossCardOnMe(card))
         {
             return true;
         }
@@ -85,7 +85,7 @@ void Player::BuyCardAndTryToss(const std::weak_ptr<DeckController>& deckControll
 
     boughtCard->Draw();
 
-    if(boughtCard->CanBeTossed(tossedCard))
+    if(tossedCard->CanTossCardOnMe(boughtCard))
     {
         TryYell();
         Core::WaitAnyKey(GetDisplayName() + ": you can toss the card you bought!");
@@ -107,7 +107,7 @@ void Player::SelectCardToToss(const std::weak_ptr<DeckController>& deckControlle
         return;
     }
 
-    if(!CardsOnHand[choice]->CanBeTossed(tossedCard))
+    if(tossedCard.IsValid() && !tossedCard->CanTossCardOnMe(CardsOnHand[choice]))
     {
         Core::LogMessage("You can't toss this card. The card must match the color or number of the " + tossedCard->GetName());
         SelectCardToToss(deckController, tossedCard);

--- a/Uno-App/Source/Private/ReverseCard.cpp
+++ b/Uno-App/Source/Private/ReverseCard.cpp
@@ -22,3 +22,8 @@ bool ReverseCard::CanBeTossed(EntityPtr<Card> other)
 
     return Card::CanBeTossed(other);
 }
+
+void ReverseCard::Execute(Match* currentMatch)
+{
+    currentMatch->ReverseFlow();
+}

--- a/Uno-App/Source/Private/ReverseCard.cpp
+++ b/Uno-App/Source/Private/ReverseCard.cpp
@@ -9,7 +9,7 @@ std::string ReverseCard::GetCardTypeName() const
     return "Reverse";
 }
 
-bool ReverseCard::CanBeTossed(EntityPtr<Card> other)
+bool ReverseCard::CanTossCardOnMe(EntityPtr<Card> other)
 {
     if(other.IsValid())
     {
@@ -20,7 +20,7 @@ bool ReverseCard::CanBeTossed(EntityPtr<Card> other)
         }
     }
 
-    return Card::CanBeTossed(other);
+    return Card::CanTossCardOnMe(other);
 }
 
 void ReverseCard::Execute(Match* currentMatch)

--- a/Uno-App/Source/Private/Round.cpp
+++ b/Uno-App/Source/Private/Round.cpp
@@ -1,22 +1,9 @@
-#include "Round.h"
+#include "Public/Round.h"
 #include "Public/DeckController.h"
-#include "Card.h"
-#include "ETurnFlow.h"
-#include "Player.h"
+#include "Public/Card.h"
+#include "Public/ETurnFlow.h"
+#include "Public/Player.h"
 #include "Core/Core.h"
-
-std::string Round::GetFlowName(const ETurnFlow& flow) const
-{
-    switch (flow)
-    {
-    case ETurnFlow::Clockwise:
-        return  "Clockwise";
-    case ETurnFlow::AntiClockwise:
-        return "Anti-clockwise";
-    }
-
-    return "Invalid flow";
-}
 
 Round::Round(int index)
     :Entity{"Round " + std::to_string(index)}, RoundIndex{index}

--- a/Uno-App/Source/Public/Card.h
+++ b/Uno-App/Source/Public/Card.h
@@ -17,7 +17,7 @@ public:
     EColor GetColor() const { return Color; }
 
     virtual std::string GetCardTypeName() const = 0;
-    virtual bool CanBeTossed(EntityPtr<Card> other);
+    virtual bool CanTossCardOnMe(EntityPtr<Card> other);
 
     static std::vector<std::string> GetDisplayCard(const Card& card);  
     static void DrawCards(const std::vector<EntityPtr<Card>>& cards, bool drawOption = false);

--- a/Uno-App/Source/Public/ETurnFlow.h
+++ b/Uno-App/Source/Public/ETurnFlow.h
@@ -1,8 +1,22 @@
 #pragma once
 #include <cstdint>
+#include <string>
 
 enum class ETurnFlow : uint8_t
 {
     Clockwise,
     AntiClockwise
 };
+
+inline std::string GetFlowName(const ETurnFlow& flow)
+{
+    switch (flow)
+    {
+    case ETurnFlow::Clockwise:
+        return  "Clockwise";
+    case ETurnFlow::AntiClockwise:
+        return "Anti-clockwise";
+    }
+
+    return "Invalid flow";
+}

--- a/Uno-App/Source/Public/IPostRoundAction.h
+++ b/Uno-App/Source/Public/IPostRoundAction.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "Match.h"
+
+class IPostRoundAction
+{
+public:
+    virtual void Execute(Match* currentMatch) = 0;
+    virtual ~IPostRoundAction() = default;
+};

--- a/Uno-App/Source/Public/JumpCard.h
+++ b/Uno-App/Source/Public/JumpCard.h
@@ -10,5 +10,5 @@ public:
 
     EntityPtr<Round> GetCustomRound(int roundIndex) override;
     
-    bool CanBeTossed(EntityPtr<Card> other) override;
+    bool CanTossCardOnMe(EntityPtr<Card> other) override;
 };

--- a/Uno-App/Source/Public/Match.h
+++ b/Uno-App/Source/Public/Match.h
@@ -4,6 +4,7 @@
 #include "Core/EntityPtr.h"
 #include "Core/Public/Entity.h"
 
+class Round;
 class Card;
 class Player;
 class DeckController;
@@ -21,7 +22,9 @@ class Match : public Entity
     EntityPtr<DeckController> Deck;
 
     EntityPtr<Player> CreatePlayer(const int& index);
+    void PostRoundAction(const EntityPtr<Card>& tossedCard);
     void IncreaseTurn();
+    EntityPtr<Round> MakeRound();
     EntityPtr<Card> LastCard; 
 
 public:

--- a/Uno-App/Source/Public/MustBuyCard.h
+++ b/Uno-App/Source/Public/MustBuyCard.h
@@ -1,16 +1,22 @@
 #pragma once
 #include "Card.h"
+#include "ICustomRoundCard.h"
+#include "IPostRoundAction.h"
 
-class MustBuyCard : public Card
+class MustBuyCard : public Card, public ICustomRoundCard
 {
     int AmountToBuy;
+    int Cumulated{0};
+    bool IsInRound{false};
 
 public:
     MustBuyCard(const EColor& color, int amountToBuy);
 
     int GetAmountToBuy() const;
+    void Cumulate(int amount);
 
     std::string GetCardTypeName() const override;
-    
-    bool CanBeTossed(EntityPtr<Card> other) override;
+    bool CanTossCardOnMe(EntityPtr<Card> other) override;
+    EntityPtr<Round> GetCustomRound(int roundIndex) override;
+    void ClearRound();
 };

--- a/Uno-App/Source/Public/MustBuyRound.cpp
+++ b/Uno-App/Source/Public/MustBuyRound.cpp
@@ -1,0 +1,48 @@
+﻿#include "MustBuyRound.h"
+#include "DeckController.h"
+#include "MustBuyCard.h"
+#include "Player.h"
+#include "Core/Core.h"
+
+MustBuyRound::MustBuyRound(const int index, const int amountToBuy)
+    :Round{index}, AmountToBuy{amountToBuy}
+{}
+
+void MustBuyRound::BuyCumulatedCards(EntityPtr<Player> currentPlayer, EntityPtr<DeckController>& deckController)
+{
+    Core::WaitAnyKey(currentPlayer->GetName() + ": you must buy " + std::to_string(AmountToBuy) + " cards.");
+    std::vector<EntityPtr<Card>> cardsToDraw;
+    cardsToDraw.reserve(AmountToBuy);
+    for (int i=0; i < AmountToBuy; i++)
+    {
+        currentPlayer->BuyDeckCard(deckController.get());
+        cardsToDraw.emplace_back(currentPlayer->GetCards().back());
+    }
+
+    Core::LogMessage(currentPlayer->GetName() + " has bought the following cards: ");
+    Card::DrawCards(cardsToDraw);
+}
+
+void MustBuyRound::RunRound(EntityPtr<Player> currentPlayer, EntityPtr<DeckController>& deckController,
+                            const ETurnFlow& turnFlow)
+{
+    DrawTurn(currentPlayer, deckController, turnFlow);
+    EntityPtr<Card> cardOnTable = deckController->GetLastTossedCard();
+    if(currentPlayer->CanTossCard(cardOnTable))
+    {
+        currentPlayer->PlayTurn(deckController.get());
+        EntityPtr<MustBuyCard> newMustBuy = static_cast<EntityPtr<MustBuyCard>>(deckController->GetLastTossedCard());
+        newMustBuy->Cumulate(AmountToBuy);
+    }
+    else
+    {
+        BuyCumulatedCards(currentPlayer, deckController);
+    }
+
+    
+    EntityPtr<MustBuyCard> lastCard = static_cast<EntityPtr<MustBuyCard>>(cardOnTable);
+    if(lastCard.IsValid())
+    {
+        lastCard->ClearRound();
+    }
+}

--- a/Uno-App/Source/Public/MustBuyRound.h
+++ b/Uno-App/Source/Public/MustBuyRound.h
@@ -1,0 +1,12 @@
+﻿#pragma once
+#include "Round.h"
+
+class MustBuyRound : public Round
+{
+    int AmountToBuy{0};
+    void BuyCumulatedCards(EntityPtr<Player> currentPlayer, EntityPtr<DeckController>& deckController);
+public:
+    MustBuyRound(int index, int amountToBuy);
+
+    void RunRound(EntityPtr<Player> currentPlayer, EntityPtr<DeckController>& deckController, const ETurnFlow& turnFlow) override;
+};

--- a/Uno-App/Source/Public/NumberCard.h
+++ b/Uno-App/Source/Public/NumberCard.h
@@ -10,5 +10,5 @@ public:
 
     int GetNumber() const { return Number; }
     std::string GetCardTypeName() const override;
-    bool CanBeTossed(EntityPtr<Card> other) override;
+    bool CanTossCardOnMe(EntityPtr<Card> other) override;
 };

--- a/Uno-App/Source/Public/Player.h
+++ b/Uno-App/Source/Public/Player.h
@@ -12,7 +12,6 @@ class Player : public Entity
     bool HasYelled;
     std::vector<EntityPtr<Card>> CardsOnHand;
     void AddCardToHand(EntityPtr<Card> card);
-    bool CanTossCard(const EntityPtr<Card>& lastTossedCard);
     EntityPtr<Card> PopCardFrom(uint32_t index);
 
     void TryYell();
@@ -26,6 +25,7 @@ public:
     Player(const std::string& name, const int& index);
     std::string GetDisplayName();
 
+    bool CanTossCard(const EntityPtr<Card>& lastTossedCard);
     void BuyDeckCard(const std::weak_ptr<DeckController>& deckController);
     void PlayTurn(const std::weak_ptr<DeckController>& deckController);
     std::string ToString();

--- a/Uno-App/Source/Public/ReverseCard.h
+++ b/Uno-App/Source/Public/ReverseCard.h
@@ -7,6 +7,6 @@ class ReverseCard : public Card, public IPostRoundAction
 public:
     ReverseCard(const EColor& color);
     std::string GetCardTypeName() const override;
-    bool CanBeTossed(EntityPtr<Card> other) override;
+    bool CanTossCardOnMe(EntityPtr<Card> other) override;
     void Execute(Match* currentMatch) override;
 };

--- a/Uno-App/Source/Public/ReverseCard.h
+++ b/Uno-App/Source/Public/ReverseCard.h
@@ -1,10 +1,12 @@
 #pragma once
 #include "Card.h"
+#include "IPostRoundAction.h"
 
-class ReverseCard : public Card
+class ReverseCard : public Card, public IPostRoundAction
 {
 public:
     ReverseCard(const EColor& color);
     std::string GetCardTypeName() const override;
     bool CanBeTossed(EntityPtr<Card> other) override;
+    void Execute(Match* currentMatch) override;
 };

--- a/Uno-App/Source/Public/Round.h
+++ b/Uno-App/Source/Public/Round.h
@@ -14,9 +14,6 @@ protected:
     
     void DrawTurn(EntityPtr<Player> player, EntityPtr<DeckController> deckController, const ETurnFlow& turnFlow) const;
 
-private:
-    std::string GetFlowName(const ETurnFlow& flow) const;
-
 public:
     Round(int index);
 

--- a/Uno-App/Source/Statics.h
+++ b/Uno-App/Source/Statics.h
@@ -1,5 +1,18 @@
 #pragma once
+#include <memory>
 
 static constexpr int COLUMN_HEIGHT = 7;
 static constexpr char DEFAULT_COLOR[] = "\033[0m";
 static constexpr int LINE_WIDTH = 11;
+
+template <typename TInterface, typename TObjectType>
+TInterface* ImplementsInterface(std::shared_ptr<TObjectType> sharedPtr)
+{
+    std::shared_ptr<TInterface> interface = std::dynamic_pointer_cast<TInterface>(sharedPtr);
+    if(interface != nullptr)
+    {
+        return interface.get();
+    }
+
+    return nullptr;
+}

--- a/Uno-Core/Source/Core/EntityPtr.h
+++ b/Uno-Core/Source/Core/EntityPtr.h
@@ -45,7 +45,7 @@ public:
     }
 
     template <typename TOther>
-    explicit operator EntityPtr<TOther>()
+    explicit operator EntityPtr<TOther>() const
     {
         std::shared_ptr<TOther> castedInstance = std::dynamic_pointer_cast<TOther>(*Instance);
         if(castedInstance)
@@ -55,6 +55,18 @@ public:
         }
 
         return EntityPtr<TOther>{};
+    }
+
+    template<class TInterface>
+    TInterface* ImplementsInterface() const
+    {
+        std::shared_ptr<TInterface> interface = std::dynamic_pointer_cast<TInterface>(*Instance);
+        if(interface != nullptr)
+        {
+            return interface.get();
+        }
+
+        return nullptr;
     }
 
     bool IsValid() const


### PR DESCRIPTION
- Implemented `IPostRoundAction` interface that can be used in the end of the round
- Implemented `MustBuyRound`
- Created a `ImplementsInterface` method on `EnittyPtr` to easily checks if a class implements an interface.
- Changed the concept of checking if a card can be tossed. Instead of the current card checks the card on table, the card on table check if the desired card can be tossed over it. It allows me to create special condition for a specific round.